### PR TITLE
Release 1.0.2

### DIFF
--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.0.2-rc.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.3
+appVersion: 3.1.1
 
 dependencies:
   - name: traefik
@@ -30,11 +30,11 @@ dependencies:
     repository: "https://cormorack.github.io/cava-media"
     condition: cava-media.enabled
   - name: cava-metadata
-    version: "0.1.2-rc.1"
+    version: "0.1.2-rc.2"
     repository: "https://cormorack.github.io/cava-metadata"
     condition: cava-metadata.enabled
   - name: cava-data
-    version: "0.1.3-rc.10"
+    version: "0.1.3"
     repository: "https://cormorack.github.io/cava-data"
     condition: cava-data.enabled
 

--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -26,15 +26,15 @@ dependencies:
     repository: "https://helm.traefik.io/traefik"
     condition: traefik.enabled
   - name: cava-media
-    version: "0.1.2"
+    version: "0.1.2-rc.22"
     repository: "https://cormorack.github.io/cava-media"
     condition: cava-media.enabled
   - name: cava-metadata
-    version: "0.1.1"
+    version: "0.1.2-rc.1"
     repository: "https://cormorack.github.io/cava-metadata"
     condition: cava-metadata.enabled
   - name: cava-data
-    version: "0.1.3-rc.4"
+    version: "0.1.3-rc.10"
     repository: "https://cormorack.github.io/cava-data"
     condition: cava-data.enabled
 

--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.2-rc.5
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.1
+appVersion: 3.2.0
 
 dependencies:
   - name: traefik

--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://helm.traefik.io/traefik"
     condition: traefik.enabled
   - name: cava-media
-    version: "0.1.2-rc.22"
+    version: "0.1.2"
     repository: "https://cormorack.github.io/cava-media"
     condition: cava-media.enabled
   - name: cava-metadata

--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.2-rc.4
+version: 1.0.2-rc.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -30,7 +30,7 @@ dependencies:
     repository: "https://cormorack.github.io/cava-media"
     condition: cava-media.enabled
   - name: cava-metadata
-    version: "0.1.2-rc.2"
+    version: "0.1.2"
     repository: "https://cormorack.github.io/cava-metadata"
     condition: cava-metadata.enabled
   - name: cava-data


### PR DESCRIPTION
## Overview

This PR updates the dependencies for io2-portal chart for `cava-metadata` and `cava-data` services. It now bumps the chart version to 1.0.2 and app version to 3.2.0