### PR TITLE
Add keda event driven autoscaler

### DIFF
--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -25,6 +25,10 @@ dependencies:
     version: "9.12.3"
     repository: "https://helm.traefik.io/traefik"
     condition: traefik.enabled
+  - name: keda
+    version: "2.3.2"
+    repository: "https://kedacore.github.io/charts"
+    condition: keda.enabled
   - name: cava-media
     version: "0.1.2"
     repository: "https://cormorack.github.io/cava-media"

--- a/io2-portal/templates/keda-rabbitmq.yaml
+++ b/io2-portal/templates/keda-rabbitmq.yaml
@@ -1,0 +1,46 @@
+{{- $dataEnabled := index .Values "cava-data" "enabled" -}}
+{{- if and .Values.keda.enabled $dataEnabled -}}
+{{- $dataWorker := index .Values "cava-data" "worker" -}}
+{{- if hasKey $dataWorker "keda" -}}
+{{- $dataWorkerKeda := index .Values "cava-data" "worker" "keda" -}}
+{{- if $dataWorkerKeda -}}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ $dataWorkerKeda.name }}-trigger-auth
+  labels:
+    {{- include "io2-portal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $dataWorkerKeda.name }}-trigger-auth
+spec:
+  {{- if $dataWorkerKeda.secretTargetRef }}
+  secretTargetRef:
+    {{- toYaml $dataWorkerKeda.secretTargetRef | nindent 4 }}
+  {{- else }}
+  secretTargetRef: []
+  {{- end }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ $dataWorkerKeda.name }}-scaledobject
+  labels:
+    {{- include "io2-portal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $dataWorkerKeda.name }}-scaledobject
+spec:
+  scaleTargetRef:
+    name: cava-data-worker
+  pollingInterval: {{ $dataWorkerKeda.pollingInterval | default 3 }}
+  minReplicaCount: {{ $dataWorkerKeda.replicas.min | default 1 }}
+  maxReplicaCount: {{ $dataWorkerKeda.replicas.max | default 10 }}
+  triggers:
+  - type: rabbitmq
+    metadata:
+      protocol: {{ $dataWorkerKeda.queue.protocol | default "amqp" | quote }}
+      queueName: {{ $dataWorkerKeda.queue.name | default "data-queue" | quote }}
+      mode: QueueLength
+      value: {{ $dataWorkerKeda.queue.length | default "2" | quote }}
+    authenticationRef:
+      name: {{ $dataWorkerKeda.name }}-trigger-auth
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/io2-portal/values.yaml
+++ b/io2-portal/values.yaml
@@ -20,6 +20,9 @@ cava-data:
 traefik:
   enabled: false
 
+keda:
+  enabled: false
+
 # Older Services ===========================
 # Data config ------------------------------
 # NOTE: Old data service including this for now to 

--- a/io2-portal/values.yaml
+++ b/io2-portal/values.yaml
@@ -16,6 +16,21 @@ cava-media:
 
 cava-data:
   enabled: false
+  # worker:
+  #   keda:
+  #     name: "cava-data-worker"
+  #     secretTargetRef: []
+  #     # secretTargetRef:
+  #     # - parameter: host
+  #     #   name: cava-secrets
+  #     #   key: rabbitmq-host
+  #     replicas:
+  #       min: 1
+  #       max: 10
+  #     pollingInterval: 3
+  #     queue:
+  #       name: "data-queue"
+  #       length: "2"
 
 traefik:
   enabled: false


### PR DESCRIPTION
This PR adds [**KEDA**](https://keda.sh/) (**Kubernetes Event Driven Autoscaling**) as dependencies to the IO2-Portal Chart.

Chart URL: https://artifacthub.io/packages/helm/kedacore/keda