### PR TITLE
Apply patches by bumping up cava-data and cava-realtime-client

### DIFF
--- a/io2-portal/Chart.yaml
+++ b/io2-portal/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.3
+version: 1.0.4-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -38,7 +38,7 @@ dependencies:
     repository: "https://cormorack.github.io/cava-metadata"
     condition: cava-metadata.enabled
   - name: cava-data
-    version: "0.1.4"
+    version: "0.1.5-rc.1"
     repository: "https://cormorack.github.io/cava-data"
     condition: cava-data.enabled
   - name: cava-realtime
@@ -46,7 +46,7 @@ dependencies:
     repository: "https://cormorack.github.io/cava-realtime"
     condition: cava-realtime.enabled
   - name: cava-realtime-client
-    version: "0.1.2"
+    version: "0.1.3-rc.1"
     repository: "https://cormorack.github.io/cava-realtime-client"
     condition: cava-realtime-client.enabled
 


### PR DESCRIPTION
This PR applies patches for `cava-data` and `cava-realtime-client`.